### PR TITLE
fix: use public base image, add Dockerfile, fix threading issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/python:3.13-slim
+
+RUN apt update && apt install -y taskwarrior gcc git
+
+WORKDIR /app
+COPY . .
+
+RUN pip install -r requirements.txt
+RUN pip install -e .
+RUN pip install gunicorn
+
+VOLUME /root/.task
+EXPOSE 8000
+
+WORKDIR /app/taskwarrior_web
+CMD ["python", "app.py"]

--- a/create_container.sh
+++ b/create_container.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 echo "Build from dhi.io/python:3.13"
-ctr=$(buildah from dhi.io/python:3.13-debian13-dev)
+ctr=$(buildah from docker.io/python:3.13-slim)
 
 echo "Upgrade pip"
 buildah run $ctr /bin/bash -c 'pip install -U pip'

--- a/taskwarrior_web/app.py
+++ b/taskwarrior_web/app.py
@@ -218,4 +218,4 @@ def completed():
 
 
 if __name__ == "__main__":
-    app.run()
+    app.run(host="0.0.0.0", port=5000, threaded=False)


### PR DESCRIPTION
- Replace private dhi.io base image with docker.io/python:3.13-slim
- Add Dockerfile for standard podman/docker build
- Fix PanicException by disabling Flask threading (taskchampion Replica is not thread-safe)
- Bind to 0.0.0.0 to allow external connections